### PR TITLE
Remove trailing code block from prompt heredoc

### DIFF
--- a/lib/pull_request_description_service.rb
+++ b/lib/pull_request_description_service.rb
@@ -60,9 +60,6 @@ module PullRequestDescriptionService
         ```
 
         Give PR description using the format above, remove sections that are not relevant to the diff.
-
-        ```md
-
       PROMPT
 
       puts "Prompt: #{prompt}"


### PR DESCRIPTION
This extra, unclosed block was adding an artifact to the bottom of all PR descriptions that were updated by this action's prompt. Removing it should clean up the final rendered PR description.

Full disclosure: I have not tested this change as it's unclear how to efficiently do that at this point.

```md

    ## Testing 👩‍🔬

    ## Dependencies 📦

    ```
```

![Screen Shot 2023-07-19 at 15 36 18](https://github.com/kieranklaassen/gpt-auto-pr-description-action/assets/47334/f2613c22-81cd-4f6f-a554-b62bc403af58)
